### PR TITLE
provide default values for getPaywallView

### DIFF
--- a/adapty-ui/src/main/java/com/adapty/ui/AdaptyUI.kt
+++ b/adapty-ui/src/main/java/com/adapty/ui/AdaptyUI.kt
@@ -107,12 +107,12 @@ public object AdaptyUI {
     public fun getPaywallView(
         activity: Activity,
         viewConfiguration: LocalizedViewConfiguration,
-        products: List<AdaptyPaywallProduct>?,
+        products: List<AdaptyPaywallProduct>? = null,
         eventListener: AdaptyUiEventListener,
         insets: AdaptyPaywallInsets = AdaptyPaywallInsets.UNSPECIFIED,
         personalizedOfferResolver: AdaptyUiPersonalizedOfferResolver = AdaptyUiPersonalizedOfferResolver.DEFAULT,
         tagResolver: AdaptyUiTagResolver = AdaptyUiTagResolver.DEFAULT,
-        timerResolver: AdaptyUiTimerResolver,
+        timerResolver: AdaptyUiTimerResolver = AdaptyUiTimerResolver.DEFAULT,
         observerModeHandler: AdaptyUiObserverModeHandler? = null,
     ): AdaptyPaywallView {
         return AdaptyPaywallView(activity).apply {


### PR DESCRIPTION
I was struggling with documentation to implement the paywall, and I spotted this mistake.

On the [Android part to present a paywall](https://adapty.io/docs/android-present-paywalls), you can actually see that `products` and `timerResolver` are optional. But since they don't have a default value, they are not.

So here I provide a default value:
- `null` for `products` as it is optional
- `AdaptyUiTimerResolver.DEFAULT` for `timerResolver` which seems to be the best choice